### PR TITLE
[Feat] #30 - APNs 세팅 및 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 RecorDream-iOS/Projects/Modules/RD-Network/Sources/Environment/config.swift
+RecorDream-iOS/Projects/RecorDream-iOS/Derived/Sources/TuistPlists+RecorDreamIOS.swift
+RecorDream-iOS/Projects/RecorDream-iOS/Resources/GoogleService-Info.plist
 
 Gemfile
 Gemfile.lock

--- a/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -19,6 +19,7 @@ public extension TargetDependency.SPM {
     static let FirebaseAnalytics = TargetDependency.external(name: "FirebaseAnalytics")
     static let FirebaseCrashlytics = TargetDependency.external(name: "FirebaseCrashlytics")
     static let FirebaseRemoteConfig = TargetDependency.external(name: "FirebaseRemoteConfig")
+    static let FirebaseMessaging = TargetDependency.external(name: "FirebaseMessaging")
     static let KakaoUser = TargetDependency.external(name: "KakaoSDKUser")
     static let KakaoAuth = TargetDependency.external(name: "KakaoSDKAuth")
     static let HeeKit = TargetDependency.external(name: "HeeKit")

--- a/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -44,6 +44,10 @@ public extension SettingsDictionary {
         merging(["SKIP_INSTALL": SettingValue(stringLiteral: value ? "YES" : "NO")])
     }
     
+    func setFirebaseDependency() -> SettingsDictionary {
+        merging(["OTHER_LDFLAGS": ["-ObjC", "$(OTHER_LDFLAGS)"]])
+    }
+    
     func setCodeSignManual() -> SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
             .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "FY8N9XTH66")])

--- a/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/RecorDream-iOS/Plugin/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -47,6 +47,7 @@ public extension SettingsDictionary {
     func setCodeSignManual() -> SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
             .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "FY8N9XTH66")])
+            .merging(["CODE_SIGN_ENTITLEMENTS": SettingValue(stringLiteral: "RecorDream-iOS.entitlements")])
     }
     
     func setProvisioningDevelopment() -> SettingsDictionary {

--- a/RecorDream-iOS/Projects/Modules/ThirdPartyLib/Project.swift
+++ b/RecorDream-iOS/Projects/Modules/ThirdPartyLib/Project.swift
@@ -7,6 +7,7 @@
 
 import ProjectDescription
 import ProjectDescriptionHelpers
+import UtilityPlugin
 
 let project = Project.makeModule(
     name: "ThirdPartyLib",
@@ -16,9 +17,6 @@ let project = Project.makeModule(
         .external(name: "RxSwift"),
         .external(name: "RxCocoa"),
         .external(name: "SnapKit"),
-        .external(name: "FirebaseAnalytics"),
-        .external(name: "FirebaseCrashlytics"),
-        .external(name: "FirebaseRemoteConfig"),
         .external(name: "KakaoSDKUser"),
         .external(name: "KakaoSDKAuth"),
         .external(name: "HeeKit")

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Derived/InfoPlists/RecorDream-iOS-Info.plist
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Derived/InfoPlists/RecorDream-iOS-Info.plist
@@ -90,6 +90,11 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Project.swift
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Project.swift
@@ -14,7 +14,8 @@ let project = Project.makeModule(
     platform: .iOS,
     product: .app,
     dependencies: [
-        .Project.RDNavigator
+        .Project.RDNavigator,
+        .SPM.FirebaseMessaging
     ],
     resources: ["Resources/**"],
     infoPlist: .extendingDefault(with: Project.baseinfoPlist)

--- a/RecorDream-iOS/Projects/RecorDream-iOS/RecorDream-iOS.entitlements
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/RecorDream-iOS.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/AppDelegate.swift
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/AppDelegate.swift
@@ -9,16 +9,15 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
+    
+    func application( _ application: UIApplication,
+                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        self.registerAPNs(to: application)
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(
         _ application: UIApplication,
         configurationForConnecting connectingSceneSession: UISceneSession,
@@ -26,9 +25,52 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(
         _ application: UIApplication,
         didDiscardSceneSessions sceneSessions: Set<UISceneSession>
     ) {}
+}
+
+// MARK: - APNs
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func registerAPNs(to application: UIApplication) {
+        UNUserNotificationCenter.current().delegate = self
+        
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+                print("permission granted: \(granted)")
+            }
+        
+        application.registerForRemoteNotifications()
+    }
+    
+    // APNS 등록 실패 시 호출
+    func application(_ application: UIApplication,
+                     didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("Failed to register for notifications: \(error.localizedDescription)")
+    }
+    
+    // APNS 등록 성공 시 호출
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let tokenPart = deviceToken.map { data in String(format: "%02.2hhx", data) }
+        let token = tokenPart.joined()
+        print("Device Token:", token)
+    }
+    
+    // foreground에 푸시을 받는 경우 처리
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.list, .banner, .sound, .badge])
+    }
+    
+    // background에서 푸시를 받는 경우 처리
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        completionHandler()
+    }
 }

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/AppDelegate.swift
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/AppDelegate.swift
@@ -7,11 +7,16 @@
 
 import UIKit
 
+import FirebaseCore
+import FirebaseMessaging
+import UserNotifications
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application( _ application: UIApplication,
                       didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        self.configureFirebase()
         self.registerAPNs(to: application)
         return true
     }
@@ -72,5 +77,31 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         completionHandler()
+    }
+}
+
+// MARK: - Firebase
+
+extension AppDelegate: MessagingDelegate {
+    func configureFirebase() {
+        FirebaseApp.configure()
+        self.configureFirebaseMessaging()
+    }
+    
+    func configureFirebaseMessaging() {
+        Messaging.messaging().delegate = self
+
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("FCM 등록토큰 가져오기 오류: \(error)")
+            } else if let token = token {
+                print("FCM 등록토큰 : \(token)")
+            }
+        }
+    }
+    
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let token = fcmToken else { return }
+        print("FCM 등록토큰 갱신: \(token)")
     }
 }

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/SceneDelegate.swift
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/SceneDelegate.swift
@@ -46,7 +46,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func sceneDidDisconnect(_ scene: UIScene) {}
     
-    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        UIApplication.shared.applicationIconBadgeNumber = 0
+    }
     
     func sceneWillResignActive(_ scene: UIScene) {}
     

--- a/RecorDream-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/RecorDream-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -14,7 +14,18 @@ public extension Project {
         resources: ResourceFileElements? = nil,
         infoPlist: InfoPlist = .default
     ) -> Project {
-        let settings: Settings = .settings(
+        
+        let defaultSettings: Settings = .settings(
+            base: .init()
+                .setFirebaseDependency()
+                .setCodeSignManual(),
+            debug: .init()
+                .setProvisioningDevelopment(),
+            release: .init()
+                .setProvisioningAppstore(),
+            defaultSettings: .recommended)
+        
+        let thirdPartySettings: Settings = .settings(
             base: .init()
                 .setCodeSignManual(),
             debug: .init()
@@ -22,6 +33,8 @@ public extension Project {
             release: .init()
                 .setProvisioningAppstore(),
             defaultSettings: .recommended)
+        
+        let settings = (name == "ThirdPartyLib") ? thirdPartySettings : defaultSettings
         
         let bundleId = (name == "RecorDream-iOS") ? "com.RecorDream.Release" : "\(organizationName).\(name)"
 

--- a/RecorDream-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/RecorDream-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -99,7 +99,8 @@ public extension Project {
         "NSMicrophoneUsageDescription": "음성을 통해 꿈을 기록하기 위해서는 마이크 이용 권한이 필요합니다.",
         "Supports opening documents in place": true,
         "Application supports iTunes file sharing": true,
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "UIBackgroundModes": ["fetch", "remote-notification"]
     ]
 }
 


### PR DESCRIPTION
## 👻 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

APNs 인증서 세팅하고, [테스트 앱](https://github.com/onmyway133/PushNotifications#opening-app-on-macos-catalina-1015)을 통해서 푸시알림 테스트도 진행했습니다. APNs Key는 서버분들께 전달하겠습니다.

11.2 추가사항
FCM 세팅하고, SettingsDictionary도 Firebase 의존성을 위해 추가했습니다.

## 🎤 PR Point
- APNs 권한 요청 메서드
- Notification 도착 시에 처리 메서드

## 참고사항
- gitignore에 googleservice.infoplist 올려놨습니다
- 파일 따로 드릴테니 아래 경로에 넣어주세요~
<img width="727" alt="image" src="https://user-images.githubusercontent.com/77208067/199474610-8a1e2e4e-a103-4af8-9951-e502fdb1f774.png">

- 빌드 세팅 바뀌었으니 `make regenerate` 해주세요!
- gitignore 바뀐 내용 갱신을 위해 `git rm -rf --cached` 해주세요!

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| Foreground| ![KakaoTalk_Photo_2022-11-01-16-27-54 001](https://user-images.githubusercontent.com/77208067/199181321-743a4b31-16e4-4e0e-8327-d88c989df0cf.jpeg)|
| Background | ![KakaoTalk_Photo_2022-11-01-16-27-54 002](https://user-images.githubusercontent.com/77208067/199181330-d3f4310d-66d6-4828-a407-32e54e440c9e.jpeg)|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #30
