### PR TITLE
[Refactor] #57 - 모듈팩토리 기능 간편화

### DIFF
--- a/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/Coordinators/MainTabBarCoordinator.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/Coordinators/MainTabBarCoordinator.swift
@@ -40,14 +40,14 @@ final class MainTabBarCoordinator: DefaultCoordinator {
     private func showDreamWriteViewController() {
         let dreamWriteVC = self.factory.instantiateDreamWriteVC(.write)
         dreamWriteVC.modalPresentationStyle = .fullScreen
-        dreamWriteVC.viewModel.closeButtonTapped
-            .subscribe(onNext: { [unowned self] in
-                dreamWriteVC.dismiss(animated: true)
-            }).disposed(by: disposeBag)
-        dreamWriteVC.viewModel.writeRequestSuccess
-            .subscribe(onNext: { [unowned self] in
-                dreamWriteVC.dismiss(animated: true)
-            }).disposed(by: disposeBag)
+//        dreamWriteVC.viewModel.closeButtonTapped
+//            .subscribe(onNext: { [unowned self] in
+//                dreamWriteVC.dismiss(animated: true)
+//            }).disposed(by: disposeBag)
+//        dreamWriteVC.viewModel.writeRequestSuccess
+//            .subscribe(onNext: { [unowned self] in
+//                dreamWriteVC.dismiss(animated: true)
+//            }).disposed(by: disposeBag)
         self.router.present(dreamWriteVC)
     }
     

--- a/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/DependencyContainer.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/DependencyContainer.swift
@@ -9,9 +9,9 @@ import UIKit
 
 import RD_DSKit
 import RD_Network
+import Presentation
 
 typealias Factory = CoordinatorFactoryProtocol & ViewControllerFactory
-typealias ViewControllerFactory = AuthViewControllerFactory  & MainTabBarControllerFactory
 
 /**
  각종 인스턴스의 의존성을 보유하는 Container Class 입니다.
@@ -29,11 +29,11 @@ open class DependencyContainer {
     
     // MARK: - Vars & Lets
     
-    var rootController: CoordinatorNavigationController
+//    var rootController: CoordinatorNavigationController
     
     // MARK: App Coordinator
     
-    internal lazy var aplicationCoordinator = self.instantiateAppCoordinator()
+//    internal lazy var aplicationCoordinator = self.instantiateAppCoordinator()
     
     // MARK: APi Manager
     
@@ -49,29 +49,29 @@ open class DependencyContainer {
     
     // MARK: - Public func
     
-    public func start() {
-        self.aplicationCoordinator.start()
-    }
+//    public func start() {
+//        self.aplicationCoordinator.start()
+//    }
     
     // MARK: - Initialization
     
-    public init(rootController: CoordinatorNavigationController) {
-        self.rootController = rootController
-        self.customizeNavigationController()
+    public init() {
+//        self.rootController = rootController
+//        self.customizeNavigationController()
     }
 }
 
 // MARK: - Private methods
 
 extension DependencyContainer {
-    private func customizeNavigationController() {
-        self.rootController.enableSwipeBack()
-        self.rootController.customizeTitle(titleColor: UIColor.white,
-                                           largeTextFont: RDDSKitFontFamily.Pretendard.semiBold.font(size: 16),
-                                           smallTextFont: RDDSKitFontFamily.Pretendard.semiBold.font(size: 16),
-                                           isTranslucent: true,
-                                           barTintColor: RDDSKitAsset.Colors.dark.color)
-        self.rootController.customizeBackButton(backButtonImage: RDDSKitAsset.Images.icnBack.image, backButtonTitleColor: .white,
-                                      shouldUseViewControllerTitles: true)
-    }
+//    private func customizeNavigationController() {
+//        self.rootController.enableSwipeBack()
+//        self.rootController.customizeTitle(titleColor: UIColor.white,
+//                                           largeTextFont: RDDSKitFontFamily.Pretendard.semiBold.font(size: 16),
+//                                           smallTextFont: RDDSKitFontFamily.Pretendard.semiBold.font(size: 16),
+//                                           isTranslucent: true,
+//                                           barTintColor: RDDSKitAsset.Colors.dark.color)
+//        self.rootController.customizeBackButton(backButtonImage: RDDSKitAsset.Images.icnBack.image, backButtonTitleColor: .white,
+//                                      shouldUseViewControllerTitles: true)
+//    }
 }

--- a/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+CoordinatorFactory.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+CoordinatorFactory.swift
@@ -12,27 +12,27 @@ import UIKit
  DependencyContainer는 스스로를 Factory로 각각의 Coordinator 안에서 기능합니다.
  따라서 각 Coordinator들은 Dependency Container가 가진 인스턴스들을 사용할 수 있습니다.
  */
-extension DependencyContainer: CoordinatorFactoryProtocol {
-    
-    /// 앱 전체의 플로우를 담당하는 AppCoordinator를 생성합니다.
-    /// - Returns: AppCoordinator는 각기 다른 플로우를 담당하는 Coordinator로의 이동을 담당합니다.
-    func instantiateAppCoordinator() -> AppCoordinator {
-        return AppCoordinator(router: Router(rootController: rootController),
-                                      factory: self as Factory,
-                                      launchInstructor: LaunchInstructor.configure())
-    }
-    
-    /// 로그인 플로우를 담당하는 AuthCoordinator를 생성합니다.
-    /// - Parameter router: 라우터는 코디네이터가 이동해야할 뷰컨트롤러로의 분기를 담당합니다.
-    func instantiateAuthCoordinator(router: RouterProtocol) -> AuthCoordinator {
-        return AuthCoordinator(router: router,
-                               factory: self)
-    }
-    
-    /// 메인 플로우를 담당하는 MainTabBarCoordinator를 생성합니다.
-    /// - Parameter router: 라우터는 코디네이터가 이동해야할 뷰컨트롤러로의 분기를 담당합니다.
-    func instantiateMainTabBarCoordinator(router: RouterProtocol) -> MainTabBarCoordinator {
-        return MainTabBarCoordinator(router: router,
-                                     factory: self)
-    }
-}
+//extension DependencyContainer: CoordinatorFactoryProtocol {
+//    
+//    /// 앱 전체의 플로우를 담당하는 AppCoordinator를 생성합니다.
+//    /// - Returns: AppCoordinator는 각기 다른 플로우를 담당하는 Coordinator로의 이동을 담당합니다.
+//    func instantiateAppCoordinator() -> AppCoordinator {
+//        return AppCoordinator(router: Router(rootController: rootController),
+//                                      factory: self as Factory,
+//                                      launchInstructor: LaunchInstructor.configure())
+//    }
+//    
+//    /// 로그인 플로우를 담당하는 AuthCoordinator를 생성합니다.
+//    /// - Parameter router: 라우터는 코디네이터가 이동해야할 뷰컨트롤러로의 분기를 담당합니다.
+//    func instantiateAuthCoordinator(router: RouterProtocol) -> AuthCoordinator {
+//        return AuthCoordinator(router: router,
+//                               factory: self)
+//    }
+//    
+//    /// 메인 플로우를 담당하는 MainTabBarCoordinator를 생성합니다.
+//    /// - Parameter router: 라우터는 코디네이터가 이동해야할 뷰컨트롤러로의 분기를 담당합니다.
+//    func instantiateMainTabBarCoordinator(router: RouterProtocol) -> MainTabBarCoordinator {
+//        return MainTabBarCoordinator(router: router,
+//                                     factory: self)
+//    }
+//}

--- a/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+ViewControllerFactory.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+ViewControllerFactory.swift
@@ -20,14 +20,15 @@ extension DependencyContainer: AuthViewControllerFactory {
 }
 
 extension DependencyContainer: MainTabBarControllerFactory {
-    func instantiateMainTabBarController() -> MainTabBarController {
+    public func instantiateMainTabBarController() -> MainTabBarController {
         let mainTabBar = MainTabBarController()
         mainTabBar.viewModel = MainTabBarViewModel()
+        mainTabBar.factory = self
         
         return mainTabBar
     }
     
-    func instantiateDreamWriteVC(_ type: DreamWriteViewModel.DreamWriteViewModelType) -> DreamWriteVC {
+    public func instantiateDreamWriteVC(_ type: DreamWriteViewModel.DreamWriteViewModelType) -> DreamWriteVC {
         let repository = DefaultDreamWriteRepository(recordService: self.recordService,
                                                      voiceService: self.voiceService)
         let useCase = DefaultDreamWriteUseCase(repository: repository)
@@ -40,11 +41,12 @@ extension DependencyContainer: MainTabBarControllerFactory {
         }
         let dreamWriteVC = DreamWriteVC()
         dreamWriteVC.viewModel = viewModel
+        dreamWriteVC.factory = self
         
         return dreamWriteVC
     }
     
-    func instantiateMyPageVC() -> MyPageVC {
+    public func instantiateMyPageVC() -> MyPageVC {
         let repository = DefaultMyPageRepository()
         let useCase = DefaultMyPageUseCase(repository: repository)
         let viewModel = MyPageViewModel(useCase: useCase)

--- a/RecorDream-iOS/Projects/Presentation/Sources/Factory/ViewControllerFactory.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/Factory/ViewControllerFactory.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import Presentation
+public typealias ViewControllerFactory = AuthViewControllerFactory  & MainTabBarControllerFactory
 
 // TODO: - Login Flow에 사용될 Factory Protocol, 추후에 구현
 public protocol AuthViewControllerFactory {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamWrite/View/DreamWriteVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamWrite/View/DreamWriteVC.swift
@@ -21,6 +21,7 @@ public class DreamWriteVC: UIViewController {
     
     private let disposeBag = DisposeBag()
     
+    public var factory: ViewControllerFactory!
     public var viewModel: DreamWriteViewModel!
     
     lazy var dataSource: UICollectionViewDiffableDataSource<Section, AnyHashable>! = nil
@@ -167,7 +168,6 @@ extension DreamWriteVC {
     
     private func bindViewModels() {
         let input = DreamWriteViewModel.Input(viewDidLoad: Observable.just(()),
-                                              closeButtonTapped: self.naviBar.rightButtonTapped.asObservable(),
                                               datePicked: self.datePicked.asObservable(),
                                               voiceRecorded: self.voiceRecorded.asObservable(),
                                               titleTextChanged: self.titleTextChanged.asObservable(),
@@ -195,9 +195,20 @@ extension DreamWriteVC {
             .bind { (strongSelf, shouldShow) in
                 strongSelf.warningFooter?.shouldShowCaution = shouldShow
             }.disposed(by: self.disposeBag)
+        
+        output.writeRequestSuccess
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.dismiss(animated: true)
+            }).disposed(by: self.disposeBag)
     }
     
     private func bindViews() {
+        naviBar.rightButtonTapped.subscribe(onNext: { [weak self] _ in
+            guard let self = self else { return }
+            self.dismiss(animated: true)
+        }).disposed(by: self.disposeBag)
+        
         recordView.recordOutput.subscribe(onNext: { [weak self] dataTimeTuple in
             guard let self = self else { return }
             self.dismissVoiceRecordView()

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamWrite/ViewModel/DreamWriteViewModel.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamWrite/ViewModel/DreamWriteViewModel.swift
@@ -20,7 +20,6 @@ public class DreamWriteViewModel: ViewModelType {
     
     public struct Input {
         let viewDidLoad: Observable<Void>
-        let closeButtonTapped: Observable<Void>
         let datePicked: Observable<String>
         let voiceRecorded: Observable<Data?>
         let titleTextChanged: Observable<String>
@@ -30,11 +29,6 @@ public class DreamWriteViewModel: ViewModelType {
         let noteTextChanged: Observable<String>
         let saveButtonTapped: Observable<Void>
     }
-    
-    // MARK: - Coordinator
-    
-    public let closeButtonTapped = PublishRelay<Void>()
-    public let writeRequestSuccess = PublishRelay<Void>()
     
     // MARK: - Outputs
     
@@ -112,10 +106,6 @@ extension DreamWriteViewModel {
             self.useCase.genreListCautionValidate(genreList: $0)
         }).disposed(by: disposeBag)
         
-        input.closeButtonTapped.subscribe(onNext: {
-            self.closeButtonTapped.accept(())
-        }).disposed(by: disposeBag)
-        
         input.saveButtonTapped.subscribe(onNext: { _ in
             print(self.writeRequestEntity.value, "상황")
             self.useCase.writeDreamRecord(request: self.writeRequestEntity.value, voiceId: self.voiceId)
@@ -134,7 +124,6 @@ extension DreamWriteViewModel {
         
         let writeRelay = useCase.writeSuccess
         writeRelay.subscribe(onNext: { entity in
-            self.writeRequestSuccess.accept(())
             output.writeRequestSuccess.accept(())
         }).disposed(by: disposeBag)
         

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/MainTabBar/MainTabBarController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/MainTabBar/MainTabBarController.swift
@@ -18,6 +18,7 @@ public class MainTabBarController: RDTabBarController {
     // MARK: - Properties
     
     private let disposeBag = DisposeBag()
+    public var factory: ViewControllerFactory!
     public var viewModel: MainTabBarViewModel!
     private let middleButtonTapped = PublishRelay<Void>()
     
@@ -65,8 +66,11 @@ extension MainTabBarController {
     }
     
     private func setMiddleButtonAction() {
-        self.middleButtonAction = {
-            self.middleButtonTapped.accept(())
+        self.middleButtonAction = { [weak self] in
+            guard let self = self else { return }
+            let dreamWriteVC = self.factory.instantiateDreamWriteVC(.write)
+            dreamWriteVC.modalPresentationStyle = .fullScreen
+            self.present(dreamWriteVC, animated: true)
         }
     }
     

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/SceneDelegate.swift
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Sources/Applications/SceneDelegate.swift
@@ -24,24 +24,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         options connectionOptions: UIScene.ConnectionOptions
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        self.window = UIWindow(windowScene: windowScene)
-        
-        rootController = CoordinatorNavigationController(rootViewController: UIViewController())
-        self.window?.rootViewController = rootController
-        self.window?.makeKeyAndVisible()
-        
-        dependencyConatiner = DependencyContainer(rootController: self.rootController!)
-        
-        self.dependencyConatiner?.start()
-        
         // MARK: - Debug 관련
-        // Coordinator를 사용하지 않고 앱을 시작하기 위해서 아래 코드를 주석해제하고 사용해주세요
-//        let rootViewController = MainTabBarController()
-//        let window = UIWindow(windowScene: windowScene)
-//        window.rootViewController = rootViewController
-//        self.window = window
-//        window.backgroundColor = .white
-//        window.makeKeyAndVisible()
+//         Coordinator를 사용하기 위한 코드
+//        self.window = UIWindow(windowScene: windowScene)
+//
+//        rootController = CoordinatorNavigationController(rootViewController: UIViewController())
+//        self.window?.rootViewController = rootController
+//        self.window?.makeKeyAndVisible()
+//
+        dependencyConatiner = DependencyContainer()
+//
+//        self.dependencyConatiner?.start()
+        let rootViewController = dependencyConatiner?.instantiateMainTabBarController()
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = rootViewController
+        self.window = window
+        window.backgroundColor = .white
+        window.makeKeyAndVisible()
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}


### PR DESCRIPTION
## 👻 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
모듈팩토리 기능 간편화

## 🎤 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

### 뷰컨트롤러 팩토리 프로토콜 위치 변경

Presentation Layer에서 모듈팩토리의 기능을 사용하기 위해 팩토리의 인터페이스를 Presentation으로 옮겼습니다.

<img width="238" alt="image" src="https://user-images.githubusercontent.com/77208067/206914433-0597e373-8c2e-4f34-a73b-2677632c3a6e.png">

### 팩토리 사용 방법

아래 사진에서 factory를 self로 지정해주는 것을 확인하실 수 있습니다.

<img width="783" alt="image" src="https://user-images.githubusercontent.com/77208067/206914548-40fcc88a-4973-40db-8b06-4458a6a3b41a.png">

factory를 참조하여 원하는 뷰 컨트롤러를 인스턴스화하시면 됩니다.

<img width="510" alt="image" src="https://user-images.githubusercontent.com/77208067/206914628-a898d4de-e23c-43da-97d0-cb351afe8832.png">

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #57 
