### PR TITLE
[Fix] #78 - 검색 뷰 데이터 바인딩 오류 수정

### DIFF
--- a/RecorDream-iOS/Projects/Data/Sources/Network/DataTransform/DreamSearchTransform.swift
+++ b/RecorDream-iOS/Projects/Data/Sources/Network/DataTransform/DreamSearchTransform.swift
@@ -16,7 +16,7 @@ extension DreamSearchResponse {
 }
 
 extension DreamSearchResponse.Records {
-    func toDomain() -> DreamSearchEntity.Records {
+    func toDomain() -> DreamSearchEntity.Record {
         return .init(id: self.id, emotion: self.emotion, date: self.date, title: self.title, genre: self.genre)
     }
 }

--- a/RecorDream-iOS/Projects/Domain/Sources/Entities/DreamSearch/DreamSearchEntity.swift
+++ b/RecorDream-iOS/Projects/Domain/Sources/Entities/DreamSearch/DreamSearchEntity.swift
@@ -10,16 +10,16 @@ import Foundation
 
 public struct DreamSearchEntity: Equatable {
     public let recordsCount: Int
-    public let records: [Records]
+    public let records: [Record]
     
-    public init(recordsCount: Int, records: [Records]) {
+    public init(recordsCount: Int, records: [Record]) {
         self.recordsCount = recordsCount
         self.records = records
     }
 }
 
 extension DreamSearchEntity {
-    public struct Records: Equatable {
+    public struct Record: Hashable {
         public let id: String?
         public let emotion: Int?
         public let date: String?

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTextField/DramSearchTextField.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTextField/DramSearchTextField.swift
@@ -52,8 +52,6 @@ extension DramSearchTextField {
             .disposed(by: disposeBag)
         self.shouldLoadResult = returnKeyTapped
             .withLatestFrom(self.rx.text) { $1 ?? "" }
-            .filter { !$0.isEmpty }
-            .distinctUntilChanged()
     }
     private func setupView() {
         self.backgroundColor = .white.withAlphaComponent(0.05)

--- a/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+ViewControllerFactory.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-Navigator/Sources/DependencyContainer/FactoryImpl/DependencyContainer+ViewControllerFactory.swift
@@ -114,31 +114,8 @@ extension DependencyContainer: MainTabBarControllerFactory {
         let viewModel = DreamSearchViewModel(useCase: useCase)
         let dreamSearchVC = DreamSearchVC()
         dreamSearchVC.viewModel = viewModel
+        dreamSearchVC.factory = self
         
         return dreamSearchVC
     }
-    
-    // MARK: - Examples
-    // 아래에 예시를 첨부합니다
-//    func makeFeedListVC(isMyPage: Bool) -> FeedListVC {
-//      let feedRepository = DefaultFeedListRepository(service: BaseService.default)
-//      let myPageRepository = DefaultMyPageRepository(service: BaseService.default)
-//      let useCase = DefaultFeedListUseCase(
-//        myPageRepository: myPageRepository,
-//        feedrepository: feedRepository)
-//      let viewModel = FeedListViewModel(useCase: useCase,
-//                                        isMyPage: isMyPage)
-//      let feedListVC =  FeedListVC.controllerFromStoryboard(.feedList)
-//      feedListVC.viewModel = viewModel
-//      return feedListVC
-//    }
-//
-//    func makeFeedReportVC(isMyPage: Bool) -> FeedReportVC {
-//      let repository = DefaultFeedReportRepository()
-//      let useCase = DefaultFeedReportUseCase(repository: repository)
-//      let viewModel = FeedReportViewModel(useCase: useCase, isMyPage: isMyPage)
-//      let feedReportVC = FeedReportVC.controllerFromStoryboard(.feedReport)
-//      feedReportVC.viewModel = viewModel
-//      return feedReportVC
-//    }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -146,11 +146,13 @@ extension HomeVC {
             .withUnretained(self)
             .subscribe(onNext: { (owner, _) in
                 let searchVC = owner.factory.instantiateSearchVC()
-                searchVC.modalPresentationStyle = .fullScreen
-                searchVC.modalTransitionStyle = .coverVertical
+                let navigation = UINavigationController(rootViewController: searchVC)
+                navigation.modalTransitionStyle = .coverVertical
+                navigation.modalPresentationStyle = .fullScreen
+                navigation.isNavigationBarHidden = true
                 guard let rdtabbarController = owner.tabBarController as? RDTabBarController else { return }
                 rdtabbarController.rdTabBar.isHidden = true
-                owner.present(searchVC, animated: true)
+                owner.present(navigation, animated: true)
             }).disposed(by: disposeBag)
     }
     

--- a/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/Cell/Layout/DreamSearchCompositionalLayout.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/Cell/Layout/DreamSearchCompositionalLayout.swift
@@ -32,13 +32,13 @@ extension DreamSearchVC {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(88.adjustedHeight)
+            heightDimension: .estimated(400.adjustedHeight)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         let sectionFooter = self.createSectionFooter()
-        section.orthogonalScrollingBehavior = .continuous
+        section.orthogonalScrollingBehavior = .none
         section.boundarySupplementaryItems = [sectionFooter]
         section.contentInsets = .init(
             top: 8, leading: 20, bottom: 0, trailing: 21

--- a/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
@@ -36,7 +36,7 @@ public class DreamSearchVC: UIViewController {
     
     // MARK: - Reactive Properties
     private let searchKeyword = PublishRelay<String>()
-    private let fetchedCount = PublishRelay<Int>()
+    private let fetchedCount = BehaviorRelay<Int>(value: 0)
     private var disposeBag = DisposeBag()
     public var factory: ViewControllerFactory!
     public var viewModel: DreamSearchViewModel!
@@ -48,6 +48,8 @@ public class DreamSearchVC: UIViewController {
         
         self.bindCollectionView()
         self.bindDismissButton()
+        self.bindTextField()
+        self.bindViewModels()
         self.setupView()
         self.setupConstraint()
         self.setDataSource()
@@ -60,7 +62,6 @@ extension DreamSearchVC {
     public func setupView() {
         self.view.backgroundColor = .black
         self.view.addSubviews(navigationBar, searchLabel, searchTextField, dreamSearchCollectionView)
-        self.searchTextField.addTarget(self, action: #selector(bindViewModels), for: .editingChanged)
     }
     public func setupConstraint() {
         navigationBar.snp.makeConstraints { make in
@@ -91,40 +92,28 @@ extension DreamSearchVC {
     }
 }
 // MARK: - DataSource
-extension DreamSearchVC {
+extension DreamSearchVC: UICollectionViewDelegate {
     private func setDataSource() {
         self.dataSource = UICollectionViewDiffableDataSource<DreamSearchResultType, AnyHashable>(collectionView: dreamSearchCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
-            if let model = itemIdentifier as? DreamSearchEntity {
-                switch DreamSearchResultType.type(indexPath.section) {
-                case .non:
-                    guard let emptyCell = collectionView.dequeueReusableCell(withReuseIdentifier: DreamSearchEmptyCVC.reuseIdentifier, for: indexPath) as? DreamSearchEmptyCVC else { return UICollectionViewCell() }
-                    self.fetchedCount.accept(0)
-                    return emptyCell
-                case .exist:
+            if let model = itemIdentifier as? DreamSearchEntity.Record {
                     guard let resultCell = collectionView.dequeueReusableCell(withReuseIdentifier: StorageExistCVC.reuseIdentifier, for: indexPath) as? StorageExistCVC else { return UICollectionViewCell() }
-                    resultCell.setData(emotion: model.records[indexPath.row].emotion ?? 0, date: model.records[indexPath.row].date ?? "", title: model.records[indexPath.row].title ?? "", tag: model.records[indexPath.row].genre ?? [])
-                    self.searchTextField.shouldLoadResult
-                        .bind(to: self.searchKeyword)
-                        .disposed(by: self.disposeBag)
-                    self.fetchedCount.accept(model.recordsCount)
+                resultCell.setData(emotion: model.emotion ?? 0, date: model.date ?? "", title: model.title ?? "", tag: model.genre ?? [])
                     return resultCell
                 }
-            }
             else {
-                return UICollectionViewCell()
+                guard let emptyCell = collectionView.dequeueReusableCell(withReuseIdentifier: DreamSearchEmptyCVC.reuseIdentifier, for: indexPath) as? DreamSearchEmptyCVC else { return UICollectionViewCell() }
+                return emptyCell
             }
         })
         
         self.dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
             switch kind {
-            case DreamSearchHeaderCVC.className:
+            case UICollectionView.elementKindSectionHeader:
                 guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: DreamSearchHeaderCVC.reuseIdentifier, for: indexPath) as? DreamSearchHeaderCVC else { return UICollectionReusableView() }
-                self.fetchedCount.subscribe(onNext: { counts in
-                    header.configureCell(counts: counts)
-                }).disposed(by: self.disposeBag)
+                header.configureCell(counts: self.fetchedCount.value)
                 return header
-            case DreamSearchEmptyCVC.className:
-                guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: DreamSearchEmptyCVC.reuseIdentifier, for: indexPath) as? DreamSearchEmptyCVC else { return UICollectionReusableView() }
+            case UICollectionView.elementKindSectionFooter:
+                guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: DreamSearchBottomCVC.reuseIdentifier, for: indexPath) as? DreamSearchBottomCVC else { return UICollectionReusableView() }
                 return footer
             default:
                 return UICollectionReusableView()
@@ -133,25 +122,22 @@ extension DreamSearchVC {
     }
     private func applySnapShot(model: DreamSearchEntity) {
         var snapshot = NSDiffableDataSourceSnapshot<DreamSearchResultType, AnyHashable>()
-        let previousItems = snapshot.itemIdentifiers(inSection: .non)
-        
-        snapshot.appendSections([.exist, .non])
-        
+        self.fetchedCount.accept(model.recordsCount)
         if model.recordsCount == 0 {
-            snapshot.appendItems([], toSection: .non)
-            snapshot.deleteItems(previousItems)
+            snapshot.appendSections([.non])
+            snapshot.appendItems([1], toSection: .non)
         } else {
-            snapshot.appendItems([], toSection: .exist)
+            snapshot.appendSections([.exist])
+            print(model.records)
+            snapshot.appendItems(model.records, toSection: .exist)
         }
-        
         self.dataSource.apply(snapshot)
         self.view.setNeedsLayout()
     }
 }
 // MARK: - Bind
 extension DreamSearchVC {
-    @objc
-    private func bindViewModels(_ sender: Any?) {
+    private func bindViewModels() {
         let input = DreamSearchViewModel.Input(currentSearchQuery: self.searchTextField.shouldLoadResult, returnButtonTapped: self.searchTextField.returnKeyTapped.asObservable())
 
         let output = self.viewModel.transform(from: input, disposeBag: self.disposeBag)
@@ -182,5 +168,11 @@ extension DreamSearchVC {
             .subscribe(onNext: { owner in
                 self.dismiss(animated: true)
             }).disposed(by: disposeBag)
+    }
+    
+    private func bindTextField() {
+        self.searchTextField.shouldLoadResult
+            .bind(to: self.searchKeyword)
+            .disposed(by: self.disposeBag)
     }
 }


### PR DESCRIPTION
## 👻 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

검색 뷰 데이터 바인딩 오류 수정

## 🎤 Fix

### 1. bindViewModel 호출 시점 수정
-> 기존 .editingChanged 이벤트마다 bindViewModel이 호출 되던 것을 viewDidload 시점에 한번만 되도록 수정했습니다.

### 2. applySnapshot 메서드 수정
-> 기존에 .non과 .exit 모두 섹션에 추가되었는데, recordCount == 0에 대해 분기처리하여 필요한 섹션만 추가했습니다.

### 3. CompositionalLayout 수정
-> section.orthogonalScrollingBehavior 을 .none으로 변경하여 기존에 좌우로 스크롤 되던 부분을 세로로 스크롤 되도록 수정했습니다.

### 4. DreamSearchTextField 내부 operator 수정
-> 아래 부분에서 filter와 distintUntilChanged()를 제거했습니다. filter로 인해 빈 스트링에 대한 검색이 되지 않았고, distinctUntilChanged로 인해 같은 스트링에 대한 연속적인 검색이 불가능했던 문제를 수정했습니다.
```swift
self.shouldLoadResult = returnKeyTapped
    .withLatestFrom(self.rx.text) { $1 ?? "" }
    .filter { !$0.isEmpty }
    .distinctUntilChanged()
````

### 5. DataSource 내부에서 반복적인 subscribe 수정
-> dataSource가 적용될 때마다 반복적으로 subscribe하던 부분을 수정했습니다.

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #78 
