### PR TITLE
[Fix] #77 - Drawing Cycle에서 layer 중복 추가로 인한 커스텀 탭바 shadow 오류 수정

### DIFF
--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
@@ -25,6 +25,7 @@ open class RDTabBar: UIView {
     
     private var shapeLayer: CALayer?
     
+    /// Drawing Cycle에서 중복 추가를 막기 위한 CALayer의 Container
     private var layerContainer: [CALayer] = []
     
     private let writeLabel: UILabel = {
@@ -168,7 +169,8 @@ extension RDTabBar {
         shapeLayer.fillColor = UIColor(rgb: 0x000000).cgColor
 
         if let oldShapeLayer = self.shapeLayer {
-            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
+            oldShapeLayer.removeFromSuperlayer()
+            self.layer.insertSublayer(shapeLayer, at: 0)
         } else {
             self.layer.insertSublayer(shapeLayer, at: 0)
         }
@@ -176,13 +178,20 @@ extension RDTabBar {
     }
     
     private func addShadowLayer() {
+        self.addDropShadow()
+        self.addInnerShadow()
+    }
+    
+    private func addDropShadow() {
         let outerDropShadowLayer = CAShapeLayer()
         outerDropShadowLayer.path = createLine()
         outerDropShadowLayer.fillColor = UIColor.clear.cgColor
         outerDropShadowLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.6, x: 0, y: -5, blur: 15, spread: 0)
         self.layer.insertSublayer(outerDropShadowLayer, at: 0)
         layerContainer.append(outerDropShadowLayer)
-        
+    }
+    
+    private func addInnerShadow() {
         let innerShadowLayer = CAShapeLayer()
         let lineHeight: CGFloat = 1
         innerShadowLayer.path = createLine(lineHeight: lineHeight)

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
@@ -25,6 +25,8 @@ open class RDTabBar: UIView {
     
     private var shapeLayer: CALayer?
     
+    private var layerContainer: [CALayer] = []
+    
     private let writeLabel: UILabel = {
         let label = UILabel()
         label.text = "기록하기"
@@ -36,6 +38,7 @@ open class RDTabBar: UIView {
     
     public override func draw(_ rect: CGRect) {
         self.addShape()
+        self.resetLayer()
         self.addShadowLayer()
     }
     
@@ -178,12 +181,21 @@ extension RDTabBar {
         shapeLayer.fillColor = UIColor.clear.cgColor
         shapeLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.6, x: 0, y: -5, blur: 15, spread: 0)
         self.layer.insertSublayer(shapeLayer, at: 1)
+        layerContainer.append(shapeLayer)
         
         let shapeLayer2 = CAShapeLayer()
         shapeLayer2.path = createLine()
         shapeLayer2.fillColor = UIColor.clear.cgColor
         shapeLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.4, x: 0, y: 0.5, blur: 10, spread: 0)
         self.layer.insertSublayer(shapeLayer2, at: 2)
+        layerContainer.append(shapeLayer)
+    }
+    
+    private func resetLayer() {
+        self.layerContainer.forEach {
+            $0.removeFromSuperlayer()
+        }
+        layerContainer = []
     }
 
     func createPath() -> CGPath {

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
@@ -180,15 +180,16 @@ extension RDTabBar {
         shapeLayer.path = createLine()
         shapeLayer.fillColor = UIColor.clear.cgColor
         shapeLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.6, x: 0, y: -5, blur: 15, spread: 0)
-        self.layer.insertSublayer(shapeLayer, at: 1)
+        self.layer.insertSublayer(shapeLayer, at: 0)
         layerContainer.append(shapeLayer)
         
         let shapeLayer2 = CAShapeLayer()
-        shapeLayer2.path = createLine()
+        shapeLayer2.path = createLine(lineHeight: 1)
+        shapeLayer2.bounds = self.shapeLayer!.bounds.offsetBy(dx: 0, dy: -2.6)
         shapeLayer2.fillColor = UIColor.clear.cgColor
-        shapeLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.4, x: 0, y: 0.5, blur: 10, spread: 0)
+        shapeLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.2, x: 0, y: 1, blur: 7, spread: 0)
         self.layer.insertSublayer(shapeLayer2, at: 2)
-        layerContainer.append(shapeLayer)
+        layerContainer.append(shapeLayer2)
     }
     
     private func resetLayer() {
@@ -219,11 +220,11 @@ extension RDTabBar {
         return path.cgPath
     }
     
-    func createLine() -> CGPath {
+    func createLine(lineHeight: CGFloat = 5) -> CGPath {
         let height: CGFloat = 37.0
         let path = UIBezierPath()
         let centerWidth = self.frame.width / 2
-        let lineHeight: CGFloat = 5
+        let lineHeight: CGFloat = lineHeight
         
         path.move(to: CGPoint(x: 0, y: 0)) // top left에서 시작하여 그린다
         

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBar.swift
@@ -176,20 +176,22 @@ extension RDTabBar {
     }
     
     private func addShadowLayer() {
-        let shapeLayer = CAShapeLayer()
-        shapeLayer.path = createLine()
-        shapeLayer.fillColor = UIColor.clear.cgColor
-        shapeLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.6, x: 0, y: -5, blur: 15, spread: 0)
-        self.layer.insertSublayer(shapeLayer, at: 0)
-        layerContainer.append(shapeLayer)
+        let outerDropShadowLayer = CAShapeLayer()
+        outerDropShadowLayer.path = createLine()
+        outerDropShadowLayer.fillColor = UIColor.clear.cgColor
+        outerDropShadowLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.6, x: 0, y: -5, blur: 15, spread: 0)
+        self.layer.insertSublayer(outerDropShadowLayer, at: 0)
+        layerContainer.append(outerDropShadowLayer)
         
-        let shapeLayer2 = CAShapeLayer()
-        shapeLayer2.path = createLine(lineHeight: 1)
-        shapeLayer2.bounds = self.shapeLayer!.bounds.offsetBy(dx: 0, dy: -2.6)
-        shapeLayer2.fillColor = UIColor.clear.cgColor
-        shapeLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.2, x: 0, y: 1, blur: 7, spread: 0)
-        self.layer.insertSublayer(shapeLayer2, at: 2)
-        layerContainer.append(shapeLayer2)
+        let innerShadowLayer = CAShapeLayer()
+        let lineHeight: CGFloat = 1
+        innerShadowLayer.path = createLine(lineHeight: lineHeight)
+        innerShadowLayer.bounds = self.shapeLayer!.bounds.offsetBy(dx: 0, dy: lineHeight)
+        innerShadowLayer.fillColor = UIColor.clear.cgColor
+        innerShadowLayer.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.2, x: 0, y: 0.1, blur: 20, spread: 0)
+        innerShadowLayer.mask = self.shapeLayer
+        self.layer.insertSublayer(innerShadowLayer, at: 2)
+        layerContainer.append(innerShadowLayer)
     }
     
     private func resetLayer() {

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBarController.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBarController.swift
@@ -85,27 +85,27 @@ extension RDTabBarController {
     }
     
     private func addShadowLayer(at btn: UIButton) {
-        let shadowLayer = CAShapeLayer()
-        shadowLayer.frame = btn.bounds
-        shadowLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.2, x: 0, y: -5, blur: 20, spread: 0)
-        btn.layer.insertSublayer(shadowLayer, at: 1)
+        let outerDropShadowLayer = CAShapeLayer()
+        outerDropShadowLayer.frame = btn.bounds
+        outerDropShadowLayer.applyShadow(color: UIColor(rgb: 0x000000), alpha: 0.2, x: 0, y: -5, blur: 20, spread: 0)
+        btn.layer.insertSublayer(outerDropShadowLayer, at: 1)
         
-        let shadowLayer2 = CAShapeLayer()
-        shadowLayer2.frame = btn.bounds
-        shadowLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.25, x: 0, y: 0, blur: 13, spread: 0)
-        shadowLayer2.masksToBounds = true
-        shadowLayer2.cornerRadius = 28
-        btn.layer.insertSublayer(shadowLayer2, at: 2)
+        let innerShadowLayer = CAShapeLayer()
+        innerShadowLayer.frame = btn.bounds
+        innerShadowLayer.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.28, x: 0, y: 0, blur: 13, spread: 0)
+        innerShadowLayer.masksToBounds = true
+        innerShadowLayer.cornerRadius = 28
+        btn.layer.insertSublayer(innerShadowLayer, at: 2)
 
         self.view.layoutIfNeeded()
         btn.layoutSubviews()
         
-        shadowLayer.shadowPath = UIBezierPath(roundedRect: btn.bounds, cornerRadius: 28).cgPath
+        outerDropShadowLayer.shadowPath = UIBezierPath(roundedRect: btn.bounds, cornerRadius: 28).cgPath
         
         let innerPath = UIBezierPath(roundedRect: btn.bounds.insetBy(dx: -5, dy: -5), cornerRadius: 28)
         let cutout = UIBezierPath(roundedRect: btn.bounds, cornerRadius: 28).reversing()
         innerPath.append(cutout)
-        shadowLayer2.shadowPath = innerPath.cgPath
+        innerShadowLayer.shadowPath = innerPath.cgPath
     }
 
     @objc func menuButtonAction(sender: UIButton) {

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBarController.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDTabBar/RDTabBarController.swift
@@ -92,7 +92,7 @@ extension RDTabBarController {
         
         let shadowLayer2 = CAShapeLayer()
         shadowLayer2.frame = btn.bounds
-        shadowLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 1, x: 0, y: 0, blur: 15, spread: 0)
+        shadowLayer2.applyShadow(color: UIColor(rgb: 0xC8CADA), alpha: 0.25, x: 0, y: 0, blur: 13, spread: 0)
         shadowLayer2.masksToBounds = true
         shadowLayer2.cornerRadius = 28
         btn.layer.insertSublayer(shadowLayer2, at: 2)


### PR DESCRIPTION
## 👻 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
Drawing Cycle에서 layer 중복 추가로 인한 커스텀 탭바 shadow 오류 수정

## 🎤 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
UIView의 drawingcycle에서 draw()메서드가 호출되는데, 이때에 레이어에 shadow를 중복으로 추가하고 있었습니다.
Container를 만들어서 해결했습니다.

또한 mask를 적용해서 탭바의 shadow가 mask 외부로 퍼져나가지 않도록 수정했습니다.

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 사진 |  ![KakaoTalk_Photo_2022-12-31-17-51-49](https://user-images.githubusercontent.com/77208067/210130985-a27c48eb-ee1a-4384-924b-9337d8d8b71b.png) |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #77 
