### PR TITLE
[Fix] #95 - 페이지 컨트롤러 스크롤뷰 애니메이션 수정

### DIFF
--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DetailRecordPageViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DetailRecordPageViewController.swift
@@ -52,6 +52,11 @@ final class DetailRecordPageViewController: UIView {
         segmentedControl.delegate = self
         pageViewController.delegate = self
         pageViewController.dataSource = self
+        for subView in pageViewController.view.subviews{
+            if subView is UIScrollView {
+                (subView as! UIScrollView).delegate = self
+            }
+        }
     }
 
     private func setLayouts() {
@@ -124,8 +129,6 @@ extension DetailRecordPageViewController: UIPageViewControllerDataSource {
         return contentPages.safeget(index: index + 1)
     }
 
-    // TODO: Animation 느린 부분 개선
-
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         guard finished,
               completed,
@@ -135,5 +138,23 @@ extension DetailRecordPageViewController: UIPageViewControllerDataSource {
 
         currentPageIndex = targetIndex
         segmentedControl.selectIndex(targetIndex, shouldAnimate: true)
+    }
+}
+
+extension DetailRecordPageViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let contentOffset = scrollView.contentOffset
+        let ratio: CGFloat = contentOffset.x / scrollView.frame.width
+        let segmentIndex = segmentedControl.selectedIndex
+        let selectorViewWidth = segmentedControl.selectorView.frame.width
+        
+        // 현재 인덱스에 따라 스크롤 가능한 범위와, selctorView의 현재 위치 비율을 정해줌
+        var (availableRatio, compensatedRatio) = (segmentIndex == 0)
+        ? (1.0...2.0, ratio - 1)
+        : (0.0...1.0, ratio)
+        
+        // 허용 범위를 벗어나면 return
+        guard availableRatio ~= ratio else { return }
+        segmentedControl.setSelectorOrigin(x: selectorViewWidth * compensatedRatio) 
     }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/RDSegmentedControl.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/RDSegmentedControl.swift
@@ -34,7 +34,7 @@ final class RDSegmentedControl: UIControl {
 
     private let buttonTitles: [String]
     private var selectorButtons: [UIButton] = []
-    private lazy var selectorView: UIControl = {
+    public lazy var selectorView: UIControl = {
         let control = UIControl(frame: CGRect(x: .zero, y: -1,
                                               width: segmentInfo.selectWidth,
                                               height: segmentInfo.selectHeight))
@@ -45,7 +45,7 @@ final class RDSegmentedControl: UIControl {
     }()
 
     private var buttonWidth: CGFloat { (self.bounds.width / buttonTitles.count.f) }
-    public private(set) var selectedIndex: Int = 0
+    public var selectedIndex: Int = 0
 
     weak var delegate: SegmentedControlDelegate?
 
@@ -83,6 +83,11 @@ extension RDSegmentedControl {
 
         guard shouldAnimate else { return }
         animateSelectedItem(to: buttonWidth * index.f)
+    }
+    
+    
+    func setSelectorOrigin(x: CGFloat) {
+        self.selectorView.frame.origin.x = x
     }
 }
 


### PR DESCRIPTION
## 👻 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

페이지 컨트롤러 스크롤뷰 애니메이션 수정

## 🎤 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

페이지 뷰컨트롤러의 스크롤뷰에 접근하여 구현했습니다.

아래와 같이 현재 인덱스에 따라 스크롤 범위와 보상된 비율을 정해서 origin을 바꾸어 주었습니다.
그리고 이전처럼 페이지가 완전히 전환되면 페이지뷰컨쪽에서 selectItem 메서드를 실행해줘서 segmentedControl.selectedIndex도 변경해 줍니다!
```swift
func scrollViewDidScroll(_ scrollView: UIScrollView) {
        let contentOffset = scrollView.contentOffset
        let ratio: CGFloat = contentOffset.x / scrollView.frame.width
        let segmentIndex = segmentedControl.selectedIndex
        let selectorViewWidth = segmentedControl.selectorView.frame.width

        // 현재 인덱스에 따라 스크롤 가능한 범위와, selctorView의 현재 위치 비율을 정해줌
        var (availableRatio, compensatedRatio) = (segmentIndex == 0)
        ? (1.0...2.0, ratio - 1)
        : (0.0...1.0, ratio)

        // 허용 범위를 벗어나면 return
        guard availableRatio ~= ratio else { return }
        segmentedControl.setSelectorOrigin(x: selectorViewWidth * compensatedRatio) 
}
```

페이지뷰컨에서 subView를 찾아서 scrollView의 delegate를 채택하게되면, 각각 뷰컨트롤러의 스크롤뷰가 페이지가 바뀜에 따라 교대로 scrollViewDelegate에 할당되어서 contentOffset이 마구 꼬이게 됩니다... 그래서 삽질을 좀 했으니 나중에 비슷한 기능을 구현하시게 되면 참고하시면 좋을 것 같아요!

그리고 개인적으로 든 생각은 역시 애플에서 주어진 인터페이스를 잘 활용할 것이지, 내부에 파고들어서 바꾸어 구현하는건 좋지 않은것 같네요...

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #95 
