### PR TITLE
[Feat] EmptyView 및 LoadingView 추가 & 세부레이아웃 수정

### DIFF
--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Derived/Sources/TuistAssets+RDDSKit.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Derived/Sources/TuistAssets+RDDSKit.swift
@@ -32,6 +32,14 @@ public enum RDDSKitAsset {
   }
   public enum Images {
     public static let icnMicTitle = RDDSKitImages(name: "icn_mic_title")
+    public static let instaBackground = RDDSKitImages(name: "instaBackground")
+    public static let instaCardBlue = RDDSKitImages(name: "insta_card_blue")
+    public static let instaCardPink = RDDSKitImages(name: "insta_card_pink")
+    public static let instaCardPurple = RDDSKitImages(name: "insta_card_purple")
+    public static let instaCardRed = RDDSKitImages(name: "insta_card_red")
+    public static let instaCardWhite = RDDSKitImages(name: "insta_card_white")
+    public static let instaCardYellow = RDDSKitImages(name: "insta_card_yellow")
+    public static let instaRogo = RDDSKitImages(name: "insta_rogo")
     public static let kakaotalk = RDDSKitImages(name: "Kakaotalk")
     public static let icnEdit = RDDSKitImages(name: "icn_edit")
     public static let icnMypage = RDDSKitImages(name: "icn_mypage")
@@ -128,15 +136,6 @@ public enum RDDSKitAsset {
     public static let rdSplashLogo = RDDSKitImages(name: "rd_splash_logo")
     public static let rdgoroMark = RDDSKitImages(name: "rdgoro_mark")
     public static let splashBackground = RDDSKitImages(name: "splash_background")
-
-    public static let instaLogo = RDDSKitImages(name: "insta_rogo")
-    public static let instaBackground = RDDSKitImages(name: "instaBackground")
-    public static let instaCardBlue = RDDSKitImages(name: "insta_card_blue")
-    public static let instaCardPink = RDDSKitImages(name: "insta_card_pink")
-    public static let instaCardPurple = RDDSKitImages(name: "insta_card_purple")
-    public static let instaCardRed = RDDSKitImages(name: "insta_card_red")
-    public static let instaCardWhite = RDDSKitImages(name: "insta_card_white")
-    public static let instaCardYellow = RDDSKitImages(name: "insta_card_yellow")
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name

--- a/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDCustomView/Home/VoiceNoticeView.swift
+++ b/RecorDream-iOS/Projects/Modules/RD-DSKit/Sources/Components/RDCustomView/Home/VoiceNoticeView.swift
@@ -1,0 +1,67 @@
+//
+//  VoiceNoticeView.swift
+//  RD-DSKit
+//
+//  Created by 김수연 on 2023/01/08.
+//  Copyright © 2023 RecorDream-iOS. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+import RxSwift
+import RxCocoa
+
+public final class VoiceNoticeView: UIView {
+
+    // MARK: - UI Components
+
+    private let micImage = UIImageView(image: RDDSKitAsset.Images.icnMic.image)
+
+    private let onlyVoiceExistLabel: UILabel = {
+        let label = UILabel()
+        label.text = "음성만 기록되어 있어요"
+        label.font = RDDSKitFontFamily.Pretendard.regular.font(size: 12)
+        label.textColor = RDDSKitAsset.Colors.white02.color
+        return label
+    }()
+
+    private enum Metric {
+        static let micSize = 24.f
+        static let contentSpacing = 4.f
+
+        static let voiceLabelTopBottom = 3.f
+    }
+
+    // MARK: - View Life Cycle
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI & Layouts
+
+    private func setUI() {
+        self.backgroundColor = .none
+    }
+
+    private func setLayout() {
+        self.addSubviews(micImage, onlyVoiceExistLabel)
+
+        micImage.snp.makeConstraints {
+            $0.top.leading.equalToSuperview()
+            $0.height.width.equalTo(Metric.micSize)
+        }
+
+        onlyVoiceExistLabel.snp.makeConstraints {
+            $0.leading.equalTo(micImage.snp.trailing).inset(Metric.contentSpacing)
+            $0.top.bottom.equalToSuperview().inset(Metric.voiceLabelTopBottom)
+        }
+    }
+}

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/DreamDetailViewModel.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/DreamDetailViewModel.swift
@@ -5,6 +5,8 @@
 //  Created by 김수연 on 2022/12/04.
 //
 
+import Foundation
+
 import Domain
 import RD_Core
 
@@ -28,6 +30,7 @@ public class DreamDetailViewModel: ViewModelType {
     
     public struct Output {
         var fetchedDetailData = BehaviorRelay<DreamDetailEntity?>(value: nil)
+        var loadingStatus = BehaviorRelay<Bool>(value: true)
     }
     
     // MARK: - Coordination
@@ -44,11 +47,13 @@ extension DreamDetailViewModel {
         self.bindOutput(output: output, disposeBag: disposeBag)
 
         input.viewDidLoad.subscribe(onNext: { _ in
+            output.loadingStatus.accept(true)
             self.useCase.fetchDetailRecord(recordId: self.dreamId)
         }).disposed(by: disposeBag)
 
         input.isModifyDismissed.subscribe(onNext: { isDismissed in
             if isDismissed {
+                output.loadingStatus.accept(true)
                 self.useCase.fetchDetailRecord(recordId: self.dreamId)
             }
         }).disposed(by: disposeBag)
@@ -61,6 +66,7 @@ extension DreamDetailViewModel {
 
         detailDreamData.compactMap { $0 }
             .subscribe(onNext: { entity in
+                output.loadingStatus.accept(false)
                 output.fetchedDetailData.accept(entity)
             }).disposed(by: disposeBag)
     }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DetailRecordPageViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DetailRecordPageViewController.swift
@@ -88,7 +88,7 @@ final class DetailRecordPageViewController: UIView {
 extension DetailRecordPageViewController {
     func setTabContentsItem(contentPages: [UIViewController]) {
         self.contentPages = contentPages
-        movePage(from: 0, to: 0, animated: true)
+        movePage(from: 0, to: 0, animated: false)
     }
 }
 
@@ -100,7 +100,7 @@ extension DetailRecordPageViewController {
         currentIndex < targetIndex ? .forward : .reverse
 
         self.pageViewController
-            .setViewControllers([targetPage], direction: direction, animated: true)
+            .setViewControllers([targetPage], direction: direction, animated: animated)
         { isCompleted in }
     }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
@@ -198,6 +198,10 @@ extension DreamDetailVC {
             .bind { (owner, entity) in
                 owner.fetchDetailDreamData(model: entity)
             }.disposed(by: self.disposeBag)
+
+        output.loadingStatus
+            .bind(to: self.rx.isLoading)
+            .disposed(by: self.disposeBag)
     }
 
     private func fetchDetailDreamData(model: DreamDetailEntity) {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamRecordViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamRecordViewController.swift
@@ -124,6 +124,7 @@ public final class DreamRecordViewController: UIViewController {
         }
 
         self.contentLabel.text = content
+        contentLabel.addLabelSpacing(kernValue: -0.14)
     }
 
     private func setAudioPlayer() {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetailMore/Share/DreamShareVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetailMore/Share/DreamShareVC.swift
@@ -45,7 +45,7 @@ public class DreamShareVC: UIViewController {
     // MARK: - UI Components
 
     private let backgroundView = UIImageView(image: RDDSKitAsset.Images.instaBackground.image)
-    private let instaLogoView = UIImageView(image: RDDSKitAsset.Images.instaLogo.image)
+    private let instaLogoView = UIImageView(image: RDDSKitAsset.Images.instaRogo.image)
 
     private let cardView = UIImageView(image: RDDSKitAsset.Images.instaCardRed.image)
 

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/HomeViewModel.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/HomeViewModel.swift
@@ -29,6 +29,7 @@ public class HomeViewModel: ViewModelType {
     
     public struct Output {
         var fetchedHomeData = BehaviorRelay<HomeEntity?>(value: nil)
+        var loadingStatus = BehaviorRelay<Bool>(value: true)
     }
     
     // MARK: - Coordination
@@ -45,6 +46,7 @@ extension HomeViewModel: DreamCardCollectionViewAdapterDataSource {
         self.bindOutput(output: output, disposeBag: disposeBag)
 
         input.viewWillAppear.subscribe(onNext: { _ in
+            output.loadingStatus.accept(true)
             self.useCase.fetchDreamRecord()
         }).disposed(by: disposeBag)
 
@@ -57,6 +59,7 @@ extension HomeViewModel: DreamCardCollectionViewAdapterDataSource {
         homeData
             .compactMap { $0 }
             .subscribe(onNext: { entity in
+                output.loadingStatus.accept(false)
                 output.fetchedHomeData.accept(entity)
 
                 let count = entity.records.count

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/CollectionView/Cell/DreamCardCVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/CollectionView/Cell/DreamCardCVC.swift
@@ -28,6 +28,10 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
         static let genreStackSpacing = 4.f
         static let genreStackHeight = 21.f
         static let noteLabelHeight = 114.f
+
+        static let voiceNoticeViewWidth = 137.adjustedWidth
+        static let voiceTopSpacing = 9.adjustedH
+        static let voiceNoticeViewHeight = 24.adjustedH
     }
     
 
@@ -76,6 +80,7 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
         return label
     }()
 
+    private var voiceNoticeView = VoiceNoticeView()
 
     // MARK: - View Life Cycles
 
@@ -179,6 +184,17 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
             return [RDDSKitAsset.Images.cardMPink.image, RDDSKitAsset.Images.feelingLShy.image]
         default:
             return [RDDSKitAsset.Images.cardMWhite.image, RDDSKitAsset.Images.feelingLBlank.image]
+        }
+    }
+
+    private func setOnlyVoiceView() {
+        self.addSubview(voiceNoticeView)
+
+        voiceNoticeView.snp.makeConstraints {
+            $0.top.equalTo(genreStackView.snp.bottom).offset(Metric.contentSpacing)
+            $0.leading.equalToSuperview().inset(Metric.contentLeadingTrailing)
+            $0.height.equalTo(Metric.voiceNoticeViewHeight)
+            $0.width.equalTo(Metric.voiceNoticeViewWidth)
         }
     }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/CollectionView/Cell/DreamCardCVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/CollectionView/Cell/DreamCardCVC.swift
@@ -18,16 +18,18 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
     static var isFromNib: Bool = false
 
     private enum Metric {
-        static let emotionImageSize = 85.f
+        static let emotionImageWidth = 85.adjustedWidth
+        static let emotionImageHeight = 85.adjustedH
 
-        static let emotionImageTop = 37.f
-        static let dateLabelTop = 18.f
-        static let contentSpacing = 8.f
-        static let contentLeadingTrailing = 22.f
+        static let emotionImageTop = 37.adjustedH
+        static let dateLabelTop = 18.adjustedH
+        static let contentSpacing = 8.adjustedH
+        static let contentLeadingTrailing = 22.adjustedWidth
+        static let dateLabelHeight = 17.f
 
         static let genreStackSpacing = 4.f
-        static let genreStackHeight = 21.f
-        static let noteLabelHeight = 114.f
+        static let genreStackHeight = 21.adjustedH
+        static let noteLabelHeight = 114.adjustedH
 
         static let voiceNoticeViewWidth = 137.adjustedWidth
         static let voiceTopSpacing = 9.adjustedH
@@ -103,8 +105,6 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
 
     private func setUI() {
         self.backgroundColor = .none
-        titleLabel.addLabelSpacing(kernValue: -0.28)
-        noteLabel.addLabelSpacing(kernValue: -0.12)
     }
 
     private func setLayout() {
@@ -117,12 +117,14 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
         emotionImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(Metric.emotionImageTop)
             $0.centerX.equalToSuperview()
-            $0.size.equalTo(Metric.emotionImageSize)
+            $0.height.equalTo(Metric.emotionImageHeight)
+            $0.width.equalTo(Metric.emotionImageWidth)
         }
 
         dateLabel.snp.makeConstraints {
             $0.top.equalTo(emotionImageView.snp.bottom).offset(Metric.dateLabelTop)
             $0.centerX.equalToSuperview()
+            $0.height.equalTo(Metric.dateLabelHeight)
         }
 
         titleLabel.snp.makeConstraints {
@@ -141,7 +143,6 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
             $0.leading.trailing.equalToSuperview().inset(Metric.contentLeadingTrailing)
             $0.height.equalTo(Metric.noteLabelHeight)
         }
-
     }
 
     func setData(model: HomeEntity.Record) {
@@ -157,6 +158,8 @@ final class DreamCardCVC: UICollectionViewCell, UICollectionViewRegisterable {
                 genreStackView.addArrangedSubview(DreamGenreTagView(type: .home, genre: $0))
             }
         }
+        titleLabel.addLabelSpacing(kernValue: -0.28)
+        noteLabel.addLabelSpacing(kernValue: -0.12)
     }
 
     func setAttributesForReuse() {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -36,15 +36,15 @@ public class HomeVC: UIViewController {
     
     private enum Metric {
         static let logoViewTop = 18.f
-        static let logoViewHeight = 24.f
+        static let logoViewHeight = 24.adjustedH
         
         static let mainLabelTop = 44.f
         static let mainLabelLeading = 22.f
         static let mainLabelSpacing = 8.f
         
         static let dreamCardTop = 64.f
-        static let dreamCardWidth = 264.f
-        static let dreamCardHeight = 392.f
+        static let dreamCardWidth = 264.adjustedWidth
+        static let dreamCardHeight = 392.adjustedH
         
         static let minimumLineSpacing = 16.f
     }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -39,6 +39,7 @@ public class HomeVC: UIViewController {
         static let logoViewHeight = 24.adjustedH
         
         static let mainLabelTop = 44.f
+        static let mainLabelTopIfEmpty = 260.adjustedH
         static let mainLabelLeading = 22.f
         static let mainLabelSpacing = 8.f
         
@@ -78,6 +79,14 @@ public class HomeVC: UIViewController {
         )
         layout.itemSize = CGSize(width: Metric.dreamCardWidth, height: Metric.dreamCardHeight)
         return collectionView
+    }()
+
+    private lazy var emptyLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = RDDSKitColors.Color.white
+        label.font = RDDSKitFontFamily.Pretendard.extraLight.font(size: 24.adjusted)
+        label.text = "꿈의 기록을 채워주세요."
+        return label
     }()
     
     // MARK: - View Life Cycle
@@ -127,18 +136,17 @@ public class HomeVC: UIViewController {
             $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTop)
             $0.leading.equalToSuperview().inset(Metric.mainLabelLeading)
         }
-        
+
         desciptionLabel.snp.makeConstraints {
             $0.top.equalTo(welcomeLabel.snp.bottom).offset(Metric.mainLabelSpacing)
             $0.leading.equalTo(welcomeLabel.snp.leading)
         }
-        
+
         dreamCardCollectionView.snp.makeConstraints {
             $0.top.equalTo(desciptionLabel.snp.bottom).offset(Metric.dreamCardTop)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(Metric.dreamCardHeight)
         }
-        
     }
 }
 
@@ -185,10 +193,42 @@ extension HomeVC {
     
     private func fetchHomeData(model: HomeEntity) {
         self.welcomeLabel.text = "반가워요, \(model.nickname)님!"
-        self.viewModel.fetchedDreamRecord = model
-        self.dreamCardCollectionViewAdapter = DreamCardCollectionViewAdapter(
-            collectionView: self.dreamCardCollectionView, adapterDataSource: self.viewModel)
-        self.setCollectionViewAdapter()
+
+        if model.records.isEmpty {
+            [self.desciptionLabel, self.dreamCardCollectionView].forEach {
+                $0.isHidden = true
+            }
+
+            self.view.addSubview(emptyLabel)
+
+            welcomeLabel.snp.remakeConstraints {
+                $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTopIfEmpty)
+                $0.centerX.equalToSuperview()
+            }
+
+            emptyLabel.snp.makeConstraints {
+                $0.top.equalTo(welcomeLabel.snp.bottom).offset(Metric.mainLabelSpacing)
+                $0.centerX.equalTo(welcomeLabel.snp.centerX)
+            }
+
+        } else {
+
+            welcomeLabel.snp.remakeConstraints {
+                $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTop)
+                $0.leading.equalToSuperview().inset(Metric.mainLabelLeading)
+            }
+
+            [self.desciptionLabel, self.dreamCardCollectionView].forEach {
+                $0.isHidden = false
+            }
+
+            self.emptyLabel.removeFromSuperview()
+
+            self.viewModel.fetchedDreamRecord = model
+            self.dreamCardCollectionViewAdapter = DreamCardCollectionViewAdapter(
+                collectionView: self.dreamCardCollectionView, adapterDataSource: self.viewModel)
+            self.setCollectionViewAdapter()
+        }
     }
     
     private func setCollectionViewAdapter() {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -189,6 +189,10 @@ extension HomeVC {
             .bind { (owner, entity) in
                 owner.fetchHomeData(model: entity)
             }.disposed(by: self.disposeBag)
+
+        output.loadingStatus
+            .bind(to: self.rx.isLoading)
+            .disposed(by: self.disposeBag)
     }
     
     private func fetchHomeData(model: HomeEntity) {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -61,7 +61,7 @@ extension StorageVC {
         self.logoView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(18)
-            make.height.equalTo(23.adjustedHeight)
+            make.height.equalTo(24.adjustedH)
         }
         self.dreamStorageCollectionView.snp.makeConstraints { make in
             make.top.equalTo(logoView.snp.bottom).offset(20)


### PR DESCRIPTION
## 👻 작업한 내용
- 홈 뷰에 로딩뷰를 추가하였습니다
- 홈 뷰에 기록이 없을 때 엠티뷰를 추가하였습니다.
- 홈 뷰에 세부 레이아웃 설정을 하였습니다. kernalValue를 지정해주기 위해서는 글자가 들어온 이후에 처리해야줘야 적용이 되기 때문에 setData 메서드 안에 추가해주었는데, 그러다보니 자동으로 추가 글을 축약해서 ...으로 표시해주는 기능이 안되네요 ! 이 부분은 다른 방법을 시도 중입니다 ! ( 레이아웃을 다시 해줘야할 것 같습니다. )


### QA 해결
- 홈 뷰와 보관함 뷰 로고 크기가 다른 이슈를 해결했습니다. 

### 이슈 해결
- 페이지 컨트롤러 오류 해결 커밋 추가했습니다 - closed #106 

+) 세부 레이아웃을 수정하긴 했는데 제목 길이나 기록 길이에 따라 달라지는 부분이 있네요.. 이건 데이터가 패치된 상태를 옵저빙해서 레이아웃을 다시 잡아주는 방식을 생각했는데 괜찮을까요?? 

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

## 🎤 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 홈 |<img src="https://user-images.githubusercontent.com/81313960/211710235-fe02a3d5-8b8f-4c21-9254-bb3e91db0901.png" width = 400>



## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #97 
