### PR TITLE
[Fix] #124 - QA 2차 반영

### DIFF
--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
@@ -23,7 +23,7 @@ public final class DreamDetailVC: UIViewController {
     public var factory: ViewControllerFactory!
 
     private let isModifyDismissed = PublishRelay<Bool>()
-    let searchedKeyword = PublishRelay<DreamSearchQuery>()
+    public var searchedKeyword: String = ""
     
     // MARK: - UI Components
 

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
@@ -23,6 +23,7 @@ public final class DreamDetailVC: UIViewController {
     public var factory: ViewControllerFactory!
 
     private let isModifyDismissed = PublishRelay<Bool>()
+    let searchedKeyword = PublishRelay<DreamSearchQuery>()
     
     // MARK: - UI Components
 

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/MyPage/View/MyPageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/MyPage/View/MyPageVC.swift
@@ -241,6 +241,8 @@ extension MyPageVC {
             .withUnretained(self)
             .bind(onNext: { (owner, _) in
                 owner.navigationController?.popViewController(animated: true)
+                guard let rdtabbarController = owner.tabBarController as? RDTabBarController else { return }
+                rdtabbarController.setTabBarHidden(false)
             })
             .disposed(by: self.disposeBag)
     }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/Layout/DreamStorageCompositionalLayout.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/Layout/DreamStorageCompositionalLayout.swift
@@ -38,7 +38,7 @@ extension StorageVC {
         let section = NSCollectionLayoutSection(group: group)
         section.boundarySupplementaryItems = [header]
         section.orthogonalScrollingBehavior = .continuous
-        section.contentInsets = .init(top: 20, leading: 16, bottom: 20, trailing: 17)
+        section.contentInsets = .init(top: 20, leading: 0, bottom: 20, trailing: 0)
         return section
     }
     

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -314,4 +314,7 @@ extension StorageVC: UICollectionViewDataSource, UICollectionViewDelegate {
             return false
         }
     }
+    public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+        return false
+    }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -90,7 +90,8 @@ extension StorageVC {
         self.dreamFilterCollectionView.snp.makeConstraints { make in
             make.height.equalTo(93.adjustedHeight)
             make.top.equalTo(logoView.snp.bottom).offset(20)
-            make.leading.trailing.equalToSuperview()
+            make.leading.equalToSuperview().offset(17)
+            make.trailing.equalToSuperview().inset(17)
         }
         self.dreamStorageCollectionView.snp.makeConstraints { make in
             make.height.equalTo(477.adjustedHeight)

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -116,7 +116,6 @@ extension StorageVC {
         StorageHeaderCVC.register(target: self.dreamStorageCollectionView)
         StorageExistCVC.register(target: self.dreamStorageCollectionView)
     }
-    
     private func resetView() {
         guard let rdtabbarController = self.tabBarController as? RDTabBarController else { return }
         rdtabbarController.setTabBarHidden(false)
@@ -174,7 +173,6 @@ extension StorageVC {
             }
         }
     }
-    
     private func applySnapshot(model: DreamStorageEntity.RecordList?) {
         guard let model = model else { return }
         var snapshot = NSDiffableDataSourceSnapshot<DreamStorageSection, AnyHashable>()
@@ -196,7 +194,6 @@ extension StorageVC {
         self.reapplySnapShot()
         self.view.setNeedsLayout()
     }
-    
     private func reapplySnapShot() {
         var snapshot = self.dataSource.snapshot()
         guard let items = snapshot.itemIdentifiers(inSection: .records) as? [DreamStorageEntity.RecordList.Record] else { return }
@@ -229,7 +226,6 @@ extension StorageVC {
             .bind(to: self.rx.isLoading)
             .disposed(by: disposeBag)
     }
-    
     private func bindViews() {
         self.fetchedCount
             .asDriver(onErrorJustReturn: 0)
@@ -300,7 +296,6 @@ extension StorageVC: UICollectionViewDataSource, UICollectionViewDelegate {
             return UICollectionReusableView()
         }
     }
-    
     public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         if collectionView == dreamFilterCollectionView {
             var selectedIndexPath: IndexPath? = nil

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -309,12 +309,4 @@ extension StorageVC: UICollectionViewDataSource, UICollectionViewDelegate {
             return false
         }
     }
-    public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        if collectionView == dreamFilterCollectionView {
-            return true
-        }
-        else {
-            return false
-        }
-    }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Storage/View/StorageVC.swift
@@ -238,7 +238,7 @@ extension StorageVC {
                 navigation.modalPresentationStyle = .fullScreen
                 navigation.isNavigationBarHidden = true
                 guard let rdtabbarController = owner.tabBarController as? RDTabBarController else { return }
-                rdtabbarController.setTabBarHidden()
+                rdtabbarController.setTabBarHidden(false)
                 owner.present(navigation, animated: true)
             }).disposed(by: self.disposeBag)
         

--- a/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
@@ -187,6 +187,7 @@ extension DreamSearchVC {
             .asDriver(onErrorJustReturn: "")
             .drive(onNext: { id in
                 let detailVC = self.factory.instantiateDetailVC(dreamId: id)
+                detailVC.searchedKeyword.accept(self.viewModel.fetchRequestEntity.value)
                 self.present(detailVC, animated: true)
             }).disposed(by: self.disposeBag)
     }

--- a/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/SearchScene/DreamSearch/View/DreamSearchVC.swift
@@ -187,7 +187,7 @@ extension DreamSearchVC {
             .asDriver(onErrorJustReturn: "")
             .drive(onNext: { id in
                 let detailVC = self.factory.instantiateDetailVC(dreamId: id)
-                detailVC.searchedKeyword.accept(self.viewModel.fetchRequestEntity.value)
+                detailVC.searchedKeyword = self.viewModel.fetchRequestEntity.value.keyword
                 self.present(detailVC, animated: true)
             }).disposed(by: self.disposeBag)
     }

--- a/RecorDream-iOS/Projects/RecorDream-iOS/Derived/InfoPlists/RecorDream-iOS-Info.plist
+++ b/RecorDream-iOS/Projects/RecorDream-iOS/Derived/InfoPlists/RecorDream-iOS-Info.plist
@@ -10,7 +10,7 @@
 	<key>Application supports iTunes file sharing</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ko</string>
 	<key>CFBundleDisplayName</key>
 	<string>레코드림</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## 👻 작업한 내용
- 검색, 마이페이지 뷰를 열었다 닫아도 보관함에서 탭바가 사라지지 않도록 수정하였습니다.
- 레이아웃 마진 값을 다시 조절하였습니다.
- 같은 감정 아이콘을 다시 클릭했을 때 비활성화 되지 않도록 수정하였습니다.
- 꿈 기록을 삭제했을 때, 보관함 뷰에서도 함께 fetch 되도록 수정하였습니다. 상세보기 내에서 `post` 해주는 `notification` 을 재사용하였습니다.
- 검색한 키워드를 상세보기로 넘겨주었습니다.
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

## 🎤 PR Point
- 검색한 키워드를 상세보기에서 하이라이트 처리해주는 부분을 겸사겸사 같이 하려고 했는데 우선 제 부분 머지부터 하고 진행하는 것이 좋을 것 같아서 먼저 PR 올립니다!
<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #124
