### PR TITLE
[Fix] 1차 QA 반영 및 버그 수정

### DIFF
--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/DreamDetailViewModel.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/DreamDetailViewModel.swift
@@ -46,9 +46,11 @@ extension DreamDetailViewModel {
         let output = Output()
         self.bindOutput(output: output, disposeBag: disposeBag)
 
-        input.viewDidLoad.subscribe(onNext: { _ in
-            output.loadingStatus.accept(true)
-            self.useCase.fetchDetailRecord(recordId: self.dreamId)
+        input.viewDidLoad
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, _) in
+                output.loadingStatus.accept(true)
+                owner.useCase.fetchDetailRecord(recordId: self.dreamId)
         }).disposed(by: disposeBag)
 
         input.isModifyDismissed.subscribe(onNext: { isDismissed in

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamDetailVC.swift
@@ -181,7 +181,7 @@ public final class DreamDetailVC: UIViewController {
         pageViewController.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(Metric.pageControllerLeadingTrailing)
             $0.top.equalTo(genreStackView.snp.bottom)
-            $0.bottom.equalTo(logoMark.snp.top).offset(Metric.pageContollerBottom)
+            $0.bottom.equalTo(logoMark.snp.top).offset(-Metric.pageContollerBottom)
         }
     }
 }
@@ -212,12 +212,19 @@ extension DreamDetailVC {
         self.titleLabel.text = model.title
         self.dateLabel.text = model.date
 
-        if genreStackView.subviews.isEmpty {
-            model.genre.forEach {
-                genreStackView.addArrangedSubview(DreamGenreTagView(type: .home, genre: $0))
-            }
-        }
+        self.setStackView(tag: model.genre)
+
         self.setupTabbarControllersChild(voiceUrl: model.voiceUrl, content: model.content, note: model.note)
+    }
+
+    private func setStackView(tag: [String]) {
+        self.genreStackView.subviews.forEach { (view) in
+            view.removeFromSuperview()
+        }
+
+        tag.forEach {
+            genreStackView.addArrangedSubview(DreamGenreTagView(type: .home, genre: $0))
+        }
     }
 
     private func setEmotionImage(emotion: Int) -> [UIImage] {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamNoteViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamNoteViewController.swift
@@ -45,6 +45,7 @@ public final class DreamNoteViewController: UIViewController {
         let label = UILabel()
         label.font = RDDSKitFontFamily.Pretendard.regular.font(size: 14)
         label.textColor = RDDSKitAsset.Colors.white01.color
+        label.numberOfLines = 0
         return label
     }()
 
@@ -89,7 +90,7 @@ public final class DreamNoteViewController: UIViewController {
 
         noteLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(Metric.noteLabelTop)
-            $0.leading.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
         }
     }
 

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamNoteViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamNoteViewController.swift
@@ -41,6 +41,14 @@ public final class DreamNoteViewController: UIViewController {
         return label
     }()
 
+    private let subScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+
+    private let contentView = UIView()
+
     private let noteLabel: UILabel = {
         let label = UILabel()
         label.font = RDDSKitFontFamily.Pretendard.regular.font(size: 14)
@@ -77,7 +85,10 @@ public final class DreamNoteViewController: UIViewController {
     }
 
     private func setLayout() {
-        self.view.addSubviews(titleLabel, placeHolder, noteLabel)
+        self.view.addSubviews(titleLabel, placeHolder, subScrollView)
+        
+        self.subScrollView.addSubview(contentView)
+        self.contentView.addSubview(noteLabel)
 
         titleLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
@@ -88,23 +99,33 @@ public final class DreamNoteViewController: UIViewController {
             $0.leading.equalToSuperview()
         }
 
-        noteLabel.snp.makeConstraints {
+        subScrollView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(Metric.noteLabelTop)
-            $0.leading.trailing.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(subScrollView.snp.width)
+        }
+
+        noteLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
 
     private func initView() {
         self.placeHolder.isHidden = true
-        self.noteLabel.isHidden = true
+        self.subScrollView.isHidden = true
     }
 
     private func bindNoteData() {
         if noteContent.isEmpty {
             self.placeHolder.isHidden = false
         } else {
-            self.noteLabel.isHidden = false
+            self.subScrollView.isHidden = false
             self.noteLabel.text = noteContent
+            self.noteLabel.addLabelSpacing(kernValue: -0.14, lineSpacing: 5.6)
         }
     }
 }

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamRecordViewController.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/DreamDetail/View/DreamRecordViewController.swift
@@ -49,6 +49,14 @@ public final class DreamRecordViewController: UIViewController {
         return recordView
     }()
 
+    private let subScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+
+    private let contentView = UIView()
+
     private let contentLabel: UILabel = {
         let label = UILabel()
         label.font = RDDSKitFontFamily.Pretendard.regular.font(size: 14)
@@ -81,7 +89,6 @@ public final class DreamRecordViewController: UIViewController {
     // MARK: - UI & Layout
     private func setUI() {
         self.view.backgroundColor = .none
-        self.contentLabel.addLabelSpacing(kernValue: -0.14, lineSpacing: 5.6)
     }
 
     private func setLayout() {
@@ -89,6 +96,7 @@ public final class DreamRecordViewController: UIViewController {
 
         titleLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
+            $0.height.equalTo(20.adjustedH)
         }
 
         // 1. 녹음 x, 내용 x
@@ -109,22 +117,39 @@ public final class DreamRecordViewController: UIViewController {
     }
 
     private func setContentLabel(isExistAudio: Bool) {
-        self.view.addSubview(contentLabel)
+        self.view.addSubview(subScrollView)
+
+        self.subScrollView.addSubview(contentView)
+        self.contentView.addSubview(contentLabel)
 
         if isExistAudio {
-            contentLabel.snp.makeConstraints {
+            subScrollView.snp.makeConstraints {
                 $0.top.equalTo(dreamAudioPlayerView.snp.bottom).offset(Metric.noteLabelTop)
-                $0.leading.trailing.equalToSuperview()
+                $0.leading.trailing.bottom.equalToSuperview()
+            }
+            contentView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+                $0.width.equalTo(subScrollView.snp.width)
+            }
+            contentLabel.snp.makeConstraints {
+                $0.edges.equalToSuperview()
             }
         } else {
-            contentLabel.snp.makeConstraints {
+            subScrollView.snp.makeConstraints {
                 $0.top.equalTo(titleLabel.snp.bottom).offset(Metric.noteLabelTop)
-                $0.leading.trailing.equalToSuperview()
+                $0.leading.trailing.bottom.equalToSuperview()
+            }
+            contentView.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+                $0.width.equalTo(subScrollView.snp.width)
+            }
+            contentLabel.snp.makeConstraints {
+                $0.edges.equalToSuperview()
             }
         }
 
         self.contentLabel.text = content
-        contentLabel.addLabelSpacing(kernValue: -0.14)
+        self.contentLabel.addLabelSpacing(kernValue: -0.14, lineSpacing: 5.6)
     }
 
     private func setAudioPlayer() {

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -247,6 +247,7 @@ extension HomeVC {
     }
 
     private func resetHomeLayoutIfNotEmpty() {
+        dreamCardCollectionView.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
 
         [self.desciptionLabel, self.dreamCardCollectionView].forEach {
             $0.isHidden = false

--- a/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
+++ b/RecorDream-iOS/Projects/Presentation/Sources/MainTabBarScene/Home/View/HomeVC.swift
@@ -99,6 +99,7 @@ public class HomeVC: UIViewController {
         self.checkShowDreamWrite()
         self.setUI()
         self.setLayout()
+        self.setCollectionViewAdapter()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -199,43 +200,17 @@ extension HomeVC {
         self.welcomeLabel.text = "반가워요, \(model.nickname)님!"
 
         if model.records.isEmpty {
-            [self.desciptionLabel, self.dreamCardCollectionView].forEach {
-                $0.isHidden = true
-            }
-
-            self.view.addSubview(emptyLabel)
-
-            welcomeLabel.snp.remakeConstraints {
-                $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTopIfEmpty)
-                $0.centerX.equalToSuperview()
-            }
-
-            emptyLabel.snp.makeConstraints {
-                $0.top.equalTo(welcomeLabel.snp.bottom).offset(Metric.mainLabelSpacing)
-                $0.centerX.equalTo(welcomeLabel.snp.centerX)
-            }
-
+            setEmptyView()
         } else {
-
-            welcomeLabel.snp.remakeConstraints {
-                $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTop)
-                $0.leading.equalToSuperview().inset(Metric.mainLabelLeading)
-            }
-
-            [self.desciptionLabel, self.dreamCardCollectionView].forEach {
-                $0.isHidden = false
-            }
-
-            self.emptyLabel.removeFromSuperview()
-
-            self.viewModel.fetchedDreamRecord = model
-            self.dreamCardCollectionViewAdapter = DreamCardCollectionViewAdapter(
-                collectionView: self.dreamCardCollectionView, adapterDataSource: self.viewModel)
-            self.setCollectionViewAdapter()
+            resetHomeLayoutIfNotEmpty()
+            self.dreamCardCollectionView.reloadData()
         }
     }
     
     private func setCollectionViewAdapter() {
+        self.dreamCardCollectionViewAdapter = DreamCardCollectionViewAdapter(
+            collectionView: self.dreamCardCollectionView, adapterDataSource: self.viewModel)
+
         self.dreamCardCollectionViewAdapter?.selectedIndex
             .compactMap { $0 }
             .withUnretained(self)
@@ -250,6 +225,39 @@ extension HomeVC {
     private func resetView() {
         guard let rdtabbarController = self.tabBarController as? RDTabBarController else { return }
         rdtabbarController.setTabBarHidden(false)
+    }
+
+    private func setEmptyView() {
+        [self.desciptionLabel, self.dreamCardCollectionView].forEach {
+            $0.isHidden = true
+        }
+
+        if !self.view.contains(emptyLabel) {
+            self.view.addSubview(emptyLabel)
+            emptyLabel.snp.makeConstraints {
+                $0.top.equalTo(welcomeLabel.snp.bottom).offset(Metric.mainLabelSpacing)
+                $0.centerX.equalTo(welcomeLabel.snp.centerX)
+            }
+        }
+
+        welcomeLabel.snp.remakeConstraints {
+            $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTopIfEmpty)
+            $0.centerX.equalToSuperview()
+        }
+    }
+
+    private func resetHomeLayoutIfNotEmpty() {
+
+        [self.desciptionLabel, self.dreamCardCollectionView].forEach {
+            $0.isHidden = false
+        }
+
+        welcomeLabel.snp.remakeConstraints {
+            $0.top.equalTo(logoView.snp.bottom).offset(Metric.mainLabelTop)
+            $0.leading.equalToSuperview().inset(Metric.mainLabelLeading)
+        }
+
+        self.emptyLabel.removeFromSuperview()
     }
     
     private func checkShowDreamWrite() {


### PR DESCRIPTION
## 👻 작업한 내용

### 1차 QA 이슈들 수정 완료 !
- #120 
1. 꿈 기록이 일정 길이 이상으로 넘어갈 경우 스크롤 되도록 수정
2. 감정 태그 변경 사항이 바로 반영되도록 수정

- #125
1. 지난 번 PR에서 언급했던 retain cycle 문제 해결
2. 지난 번 PR에서 언급했던 중복구독 문제 해결

- 기디 측에서 별도로 요청한 사항
1. 다른 뷰에 있다가 홈으로 돌아올 경우, 첫 번째 카드로 리셋
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

## 🎤 PR Point

### 저번 PR에서 남겨주신 코드리뷰 반영하였습니다 !! 어떻게 해결했는지 코멘트 남길게요.

코드를 짰을 당시에 집중을 안했었나봐요.. 엉망진창이네.. 그때 코드리뷰 피드백 남겨주신 것처럼
1. 한개의 메서드 내부에서 너무 많은 역할을 담당 -> 하나의 메서드가 하나의 역할만을 하도록 분리 
2. HomeEntity의 경우 ViewModel에서 이미 받아오고 있기 때문에 굳이 viewModel의 fetchedDreamRecord에 접근해서 다시 넣어줄 필요가 없었음.
3. fetch하면서 setAdapter를 해주는 과정에서 중복 구독이 일어나고 있음 : CollectionView의 데이터를 업데이트하기 위해 Adapter를 다시 만들어줄 필요가 없음 -> 넘 어렵게 생각했었네요 ㅎ... 단순히 reloadData로 해결 .. 다시 한번 중복구독이 어떤건지 파악할 수 있었어요.. 구독해주는 코드는 뷰디드로드에서 1번만 !! 

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->



## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #120 
- Resolved: #125 
